### PR TITLE
Add assertions to Storage class

### DIFF
--- a/src/main/java/duke/storage/Storage.java
+++ b/src/main/java/duke/storage/Storage.java
@@ -57,12 +57,15 @@ public class Storage {
                 String line = myReader.nextLine();
 
                 // While creating duke.task from String, possibly corrupted file.
-                Task task;
+                Task task = null;
                 try {
                     task = createTaskFromString(line);
                 } catch (DukeException e) {
                     throw new DukeException(ERROR_FAILED_LOAD_CORRUPTED_FILE);
                 }
+
+                // asserts task to be added is not null
+                assert(task != null);
 
                 // Add successfully created duke.task to the list.
                 tasks.add(task);
@@ -107,6 +110,11 @@ public class Storage {
         try {
             FileWriter writer = new FileWriter(filepath);
             String fileString = tasks.getFileString(DELIMITER, IDENTIFIER_DONE, IDENTIFIER_NOT_DONE);
+
+            // asserts fileString is not empty or null
+            assert(fileString != null);
+            assert(!fileString.equals(""));
+
             writer.write(fileString);
             writer.flush();
             writer.close();


### PR DESCRIPTION
Empty task may be added to the TaskList while reading from Storage.

Asserting task added in load method to be not null ensures that
no null object is added to TaskList.

Empty task may be written to the storage file.

Asserting task written in writeTasksToFile method to be not empty
or null ensures that no empty strings are written to TaskList and
prevent Null Pointer errors.